### PR TITLE
fix(petitions): prevent double petition creation on submit

### DIFF
--- a/assets/js/pages/create-petition-page.tsx
+++ b/assets/js/pages/create-petition-page.tsx
@@ -124,6 +124,7 @@ export default function CreatePetitionPage() {
     targetAudience: "",
   })
   const [showSuccess, setShowSuccess] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
 
   const {
@@ -155,20 +156,36 @@ export default function CreatePetitionPage() {
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
-    const result = await createPetition({
-      input: {
-        title: formData.title,
-        description: formData.description,
-        status: "open",
-        goal: parseInt(formData.goal),
-        categoryId: categories.find((category) => formData.category === category.name)?.id,
-      },
-      headers: buildCSRFHeaders(),
-    })
+    e.preventDefault()
+    if (isSubmitting) return
+    setIsSubmitting(true)
+    try {
+      const result = await createPetition({
+        input: {
+          title: formData.title,
+          description: formData.description,
+          status: "open",
+          goal: parseInt(formData.goal),
+          categoryId: categories.find((category) => formData.category === category.name)?.id,
+        },
+        headers: buildCSRFHeaders(),
+      })
+      if (result.success) {
+        setShowSuccess(true)
+        setFormData({
+          title: "",
+          description: "",
+          category: "",
+          goal: "1000",
+          targetAudience: "",
+        })
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   const handleChange = (field: string, value: string) => {
-    console.log(field, value)
     setFormData((prev) => ({ ...prev, [field]: value }))
   }
 
@@ -359,9 +376,8 @@ export default function CreatePetitionPage() {
                 {/* Submit Button */}
                 <div className="flex gap-4 pt-4">
                   <Button
-                    onClick={handleSubmit}
                     type="submit"
-                    disabled={!isFormValid}
+                    disabled={!isFormValid || isSubmitting}
                     className="flex-1"
                   >
                     Create Petition

--- a/assets/js/pages/create-petition-page.tsx
+++ b/assets/js/pages/create-petition-page.tsx
@@ -124,6 +124,7 @@ export default function CreatePetitionPage() {
     targetAudience: "",
   })
   const [showSuccess, setShowSuccess] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
 
@@ -159,6 +160,7 @@ export default function CreatePetitionPage() {
     e.preventDefault()
     if (isSubmitting) return
     setIsSubmitting(true)
+    setSubmitError(null)
     try {
       const result = await createPetition({
         input: {
@@ -170,7 +172,10 @@ export default function CreatePetitionPage() {
         },
         headers: buildCSRFHeaders(),
       })
-      if (result.success) {
+      if (result.success === false) {
+        const message = result.errors.map((error) => error.message).join(" ")
+        setSubmitError(message || "Something went wrong. Please try again.")
+      } else {
         setShowSuccess(true)
         setFormData({
           title: "",
@@ -180,6 +185,8 @@ export default function CreatePetitionPage() {
           targetAudience: "",
         })
       }
+    } catch {
+      setSubmitError("Something went wrong. Please try again.")
     } finally {
       setIsSubmitting(false)
     }
@@ -256,6 +263,13 @@ export default function CreatePetitionPage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
+              {submitError && (
+                <Alert variant="destructive" className="mb-6">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertTitle>Unable to Create Petition</AlertTitle>
+                  <AlertDescription>{submitError}</AlertDescription>
+                </Alert>
+              )}
               <form onSubmit={handleSubmit} className="space-y-6">
                 {/* Title */}
                 <div className="space-y-2">


### PR DESCRIPTION
## Fixes #2 — Petition creation inserts 2 petitions

### Root cause
In `assets/js/pages/create-petition-page.tsx`, the submit button had **both** `onClick={handleSubmit}` **and** `type="submit"` inside a `<form onSubmit={handleSubmit}>`, and `handleSubmit` never called `e.preventDefault()`. One click therefore fired `createPetition` **twice**, and the browser also performed a native form submission/reload.

### Changes (restrained, no redesign)
- Removed `onClick={handleSubmit}` from the submit button; kept `type="submit"` (form `onSubmit` remains the single submission path).
- Added `e.preventDefault()` at the top of `handleSubmit`.
- Added an `isSubmitting` guard (`useState`): early-return when already submitting, and the button is disabled while submitting — so double-clicks / Enter cannot fire duplicate submissions.
- Set `setShowSuccess(true)` (the state existed but was never set) and reset the form fields only after `result.success`.
- Removed the stray `console.log(field, value)` in `handleChange`.

### Verification
- `bunx tsc --noEmit` — clean
- `mix precommit` — green (`compile --warnings-as-errors`, `deps.unlock --unused` no-op, `format` no changes, 5 tests passed)

### Testing caveat
Click behaviour was **not** browser-E2E-tested: this repo has no JS/browser test framework for the SPA (no vitest/playwright/etc. — confirmed in `assets/package.json`). The fix is structural (the duplicate handler is removed at its source) and typechecked, but a true browser-level regression test isn't possible without adding a test framework, which is out of scope for this bugfix.