### PR TITLE
fix(css): deduplicate tailwind import + dark variant; scan components dir

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -10,6 +10,7 @@
 @source "../../deps/ash_authentication_phoenix";
 @source "../css";
 @source "../js";
+@source "../components";
 @source "../../lib/petitionu_web";
 
 /* A Tailwind plugin that makes "hero-#{ICON}" classes available.
@@ -102,9 +103,6 @@
 @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);
 @custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
 
-/* Use the data attribute for dark mode  */
-@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
-
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session],
 [data-phx-teleported-src] {
@@ -114,7 +112,6 @@
 /* This file is for your main application CSS */
 
 /* Custom globals.css integration */
-@import "tailwindcss";
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
## Summary

Fixes #1 — dropdowns (radix `Select`) were not rendering properly. Three CSS-side root causes in `assets/css/app.css`:

1. **Duplicate tailwind entry import** — removed the second bare `@import "tailwindcss";` (in the "Custom globals.css integration" block). It re-enabled default source detection and double-processed the Tailwind entry, causing the theme-layer cascade to be emitted **4×** in the built CSS. Kept `@import "tw-animate-css";` — the select's `animate-in/out` utilities come from it.
2. **Conflicting `dark` variants** — removed the daisyUI `@custom-variant dark (&:where([data-theme=dark], …))`. The React app uses the shadcn `.dark` variant (`&:is(.dark *)`, kept), and daisyUI's theme plugin emits its own `[data-theme]` rules independently of the `dark` variant.
3. **`assets/components` was never scanned** — added `@source "../components";`. The shadcn/radix-ui primitives live there (`assets/components/ui/select.tsx`), outside every declared source root, so **none of their utilities were in the compiled CSS**: `bg-popover`/`text-popover-foreground`, `max-h-(--radix-select-content-available-height)`, the `fade/zoom/slide` open–close transitions, etc. This contributed directly to the unstyled dropdown content.

Left untouched (per scope): the daisyUI plugin blocks and the heroicons plugin (the ash_authentication_phoenix LiveView auth pages use daisyUI classes via the router overrides), the LiveView `[data-phx-session]` display rule, the shadcn token blocks, and all `mix.exs`/`mix.lock`/`package.json`/TS/Elixir sources. CSS only.

## Verification (build + runtime, no test framework exists for CSS)

| Check | Before | After |
|---|---|---|
| `@layer theme` occurrences in built `priv/static/assets/css/app.css` | **4** | **2** |
| Built CSS size (removal-only diff, no `@source` line) | 136,752 B | **132,696 B** (−4,056 B, ~3%) |
| Radix select utilities in built CSS (`max-height: var(--radix-select-content-available-height)`, `bg-popover`, `slide-in-from-top-2`, `zoom-out-95`) | **absent** | **present** |
| `animate-in` (tw-animate) | present | present (utility definition + generated usage) |
| `--popover` token rules | present | present |
| daisyUI `[data-theme=dark]` rule (plugin-emitted) | present | present (unchanged) |
| `.dark` variant styles | conflicted | shadcn `&:is(.dark *)` only |
| Tailwind build errors | — | none (`tailwindcss v4.1.7` completed cleanly) |

**Size honesty:** the net result with the `@source "../components"` line is 152,237 B — *larger* than the 136,752 B baseline, because the previously-missing select utilities (~19.5 KB) are now generated. The required de-duplication change alone shrinks the output ~3%; the growth is the fix working, not a regression.

Runtime check (server booted with `PORT=4012 mix phx.server`): `/assets/css/app.css` → **200** (2 theme layers served, radix max-h var present), `/ash-typescript` → **200**, `/` → **200**. Server then stopped.

**Not performed:** visual dropdown QA in a real browser — no browser-level verification was done for this change.

## Notes

- The radix select uses Tailwind v4 CSS-variable arbitrary syntax (`max-h-(--radix-select-content-available-height)`, `origin-(--radix-select-content-transform-origin)`) which requires the newer Tailwind CLI — already shipped by #4 (`chore/deps-update`, tailwind 0.5.1 / CLI 4.1.7, confirmed in `mix.lock` and build output). Without that CLI version these utilities would not compile.
- `AGENTS.md` says `@apply` should not be used; `app.css` still contains `@apply` inside `@layer base` (lines ~210–217). Pre-existing and out of scope for this PR, but flagged as a guideline violation for a follow-up.
- The `@source "../components"` line was contributed into this worktree by a sibling agent in the same orchestration run (subagent `sa-3-950b0bd2`); it was independently re-verified here (select utilities confirmed present in the compiled output) before being retained.
- `mix precommit` (full test suite) was deliberately skipped per the task's instruction that tests were not needed; `mix compile --warning-as-errors` passes clean.