### PR TITLE
fix(comments): make comment creation work and enforce actor-based authorization

### DIFF
--- a/assets/js/ash_rpc.ts
+++ b/assets/js/ash_rpc.ts
@@ -2223,8 +2223,7 @@ export async function validateRequestToJoinClassroom(
 export type CreateCommentInput = {
   text?: string | null;
   parentCommentId?: UUIDv7 | null;
-  petitionId: UUID;
-  userId: UUID;
+  petitionId: UUIDv7;
 };
 
 export type CreateCommentFields = UnifiedFieldSelection<CommentResourceSchema>[];

--- a/assets/js/ash_types.ts
+++ b/assets/js/ash_types.ts
@@ -230,27 +230,30 @@ export type ClassroomMembershipAttributesOnlySchema = {
 // Comment Schema
 export type CommentResourceSchema = {
   __type: "Resource";
-  __primitiveFields: "id" | "text" | "sentiment" | "insertedAt" | "updatedAt" | "userId";
+  __primitiveFields: "id" | "text" | "sentiment" | "insertedAt" | "updatedAt" | "userId" | "petitionId";
   id: UUIDv7;
   text: string | null;
   sentiment: string | null;
   insertedAt: UtcDateTimeUsec;
   updatedAt: UtcDateTimeUsec;
   userId: UUID | null;
+  petitionId: UUID | null;
   user: { __type: "Relationship"; __resource: UserResourceSchema | null; };
+  petition: { __type: "Relationship"; __resource: PetitionResourceSchema | null; };
 };
 
 
 
 export type CommentAttributesOnlySchema = {
   __type: "Resource";
-  __primitiveFields: "id" | "text" | "sentiment" | "insertedAt" | "updatedAt" | "userId";
+  __primitiveFields: "id" | "text" | "sentiment" | "insertedAt" | "updatedAt" | "userId" | "petitionId";
   id: UUIDv7;
   text: string | null;
   sentiment: string | null;
   insertedAt: UtcDateTimeUsec;
   updatedAt: UtcDateTimeUsec;
   userId: UUID | null;
+  petitionId: UUID | null;
 };
 
 
@@ -949,8 +952,17 @@ export type CommentFilterInput = {
     isNil?: boolean;
   };
 
+  petitionId?: {
+    eq?: UUID;
+    notEq?: UUID;
+    in?: Array<UUID>;
+    isNil?: boolean;
+  };
+
 
   user?: UserFilterInput;
+
+  petition?: PetitionFilterInput;
 
 };
 export type PetitionFilterInput = {
@@ -1268,7 +1280,7 @@ export type ClassroomFilterField = (typeof classroomFilterFields)[number];
 export const classroomMembershipFilterFields = ["id", "role", "status", "joinedAt", "insertedAt", "updatedAt", "classroomId", "userId", "invitedById", "classroom", "user", "invitedBy"] as const;
 export type ClassroomMembershipFilterField = (typeof classroomMembershipFilterFields)[number];
 
-export const commentFilterFields = ["id", "text", "sentiment", "insertedAt", "updatedAt", "userId", "user"] as const;
+export const commentFilterFields = ["id", "text", "sentiment", "insertedAt", "updatedAt", "userId", "petitionId", "user", "petition"] as const;
 export type CommentFilterField = (typeof commentFilterFields)[number];
 
 export const petitionFilterFields = ["id", "title", "description", "status", "goal", "allowComments", "isAnonymous", "deadline", "insertedAt", "updatedAt", "userId", "categoryId", "classroomId", "signaturesCount", "isClassroomPetition", "daysLeft", "author", "trending", "user", "category", "classroom", "updates", "comments", "signatures"] as const;
@@ -1302,7 +1314,7 @@ export type ClassroomSortField = (typeof classroomSortFields)[number];
 export const classroomMembershipSortFields = ["id", "role", "status", "joinedAt", "insertedAt", "updatedAt", "classroomId", "userId", "invitedById"] as const;
 export type ClassroomMembershipSortField = (typeof classroomMembershipSortFields)[number];
 
-export const commentSortFields = ["id", "text", "sentiment", "insertedAt", "updatedAt", "userId"] as const;
+export const commentSortFields = ["id", "text", "sentiment", "insertedAt", "updatedAt", "userId", "petitionId"] as const;
 export type CommentSortField = (typeof commentSortFields)[number];
 
 export const petitionSortFields = ["id", "title", "description", "status", "goal", "allowComments", "isAnonymous", "deadline", "insertedAt", "updatedAt", "userId", "categoryId", "classroomId", "signaturesCount", "isClassroomPetition", "daysLeft", "author", "trending"] as const;

--- a/assets/js/pages/petition-index-page.tsx
+++ b/assets/js/pages/petition-index-page.tsx
@@ -1,10 +1,16 @@
+import { useState } from "react"
 import { User, Calendar, TrendingUp, Share2, Flag, CheckCircle2, Clock } from "lucide-react"
 import { useParams } from "react-router-dom"
-import { buildCSRFHeaders, getPetitions, getUsers, PetitionResourceSchema } from "../ash_rpc"
+import {
+  buildCSRFHeaders,
+  createComment,
+  getPetitions,
+  PetitionResourceSchema,
+} from "../ash_rpc"
 import { CleanResource } from "@/lib/types"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 type Petition = CleanResource<PetitionResourceSchema>
 // type Petition = InferGetPetitionsResult<>
@@ -247,7 +253,7 @@ export default function PetitionIndexPage() {
           "deadline",
           // { user: ["firstName", "lastName", "email"] },
           { category: ["id", "name", "description"] },
-          { comments: ["sentiment", "text"] },
+          { comments: ["id", "sentiment", "text", { user: ["firstName", "lastName"] }] },
           { signatures: ["reason", "userAgent"] },
           { updates: ["id", "title", "body"] },
         ],
@@ -269,27 +275,39 @@ export default function PetitionIndexPage() {
     },
   })
 
-  const userQuery = useQuery({
-    queryKey: ["user"],
-    queryFn: async () => {
-      const result = await getUsers({
-        fields: ["firstName", "lastName", "email"],
-        // filter: { id: { eq: 1 } },
+  const [commentText, setCommentText] = useState("")
+  const [commentError, setCommentError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+
+  const createCommentMutation = useMutation({
+    mutationFn: async (petitionId: string) => {
+      const result = await createComment({
+        input: { text: commentText.trim(), petitionId },
         headers: buildCSRFHeaders(),
       })
 
-      if (!result.success) {
-        // @ts-ignore
-        result.errors.forEach((error) => {
-          console.log(error.message, error.field, error.code)
-        })
-        throw new Error("Failed to fetch user")
+      if (result.success === false) {
+        throw new Error(result.errors[0]?.message || "Failed to post comment")
       }
 
-      const fetchedUser = result.data[0]
-      return fetchedUser
+      return result.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["petition", id] })
+      setCommentText("")
+      setCommentError(null)
+    },
+    onError: (error: Error) => {
+      setCommentError(error.message)
     },
   })
+
+  const handleCommentSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!petition || !commentText.trim()) return
+    setCommentError(null)
+    createCommentMutation.mutate(petition.id)
+  }
 
   switch (status) {
     case "pending":
@@ -415,19 +433,24 @@ export default function PetitionIndexPage() {
               {/* Comment Form */}
               <div className="bg-card border border-border rounded-lg p-6 mb-6">
                 <h3 className="text-lg font-semibold text-foreground mb-4">Leave a Comment</h3>
-                <form className="space-y-4">
+                <form onSubmit={handleCommentSubmit} className="space-y-4">
                   <div>
                     <Textarea
                       placeholder="Share your thoughts on this petition..."
                       rows={4}
                       className="resize-none"
+                      value={commentText}
+                      onChange={(e) => setCommentText(e.target.value)}
                     />
                   </div>
+                  {commentError && <p className="text-sm text-destructive">{commentError}</p>}
                   <div className="flex items-center justify-between">
                     <p className="text-xs text-muted-foreground">
                       Be respectful and constructive in your comments
                     </p>
-                    <button type="submit">Post Comment</button>
+                    <button type="submit" disabled={createCommentMutation.isPending}>
+                      {createCommentMutation.isPending ? "Posting..." : "Post Comment"}
+                    </button>
                   </div>
                 </form>
               </div>
@@ -440,8 +463,10 @@ export default function PetitionIndexPage() {
                       <div>
                         <div className="flex items-center gap-2 mb-1">
                           <span className="font-semibold text-foreground">
-                            Anon User
-                            {/*{`${comment.user.firstName} ${comment.user.lastName}`}*/}
+                            {comment.user
+                              ? `${comment.user.firstName ?? ""} ${comment.user.lastName ?? ""}`.trim() ||
+                                "Anon User"
+                              : "Anon User"}
                           </span>
                           <span className="text-xs text-muted-foreground">•</span>
                           <span className="text-xs text-muted-foreground">{"Student"}</span>

--- a/lib/petitionu/post/comment.ex
+++ b/lib/petitionu/post/comment.ex
@@ -2,6 +2,7 @@ defmodule Petitionu.Post.Comment do
   use Ash.Resource,
     domain: Petitionu.Post,
     data_layer: AshPostgres.DataLayer,
+    authorizers: [Ash.Policy.Authorizer],
     extensions: [AshTypescript.Resource]
 
   postgres do
@@ -20,21 +21,34 @@ defmodule Petitionu.Post.Comment do
       primary? true
       accept [:text, :parent_comment_id]
 
-      argument :petition_id, :uuid do
+      argument :petition_id, :uuid_v7 do
         allow_nil? false
       end
 
-      argument :user_id, :uuid do
-        allow_nil? false
-      end
-
+      change relate_actor(:user, allow_nil?: true)
       change manage_relationship(:petition_id, :petition, type: :append_and_remove)
-      change manage_relationship(:user_id, :user, type: :append_and_remove)
     end
 
     update :update do
       primary? true
       accept [:text]
+    end
+  end
+
+  policies do
+    # Comments are public content
+    policy action_type(:read) do
+      authorize_if always()
+    end
+
+    # Only authenticated users can create comments
+    policy action(:create) do
+      authorize_if actor_present()
+    end
+
+    # Only the author can update or destroy their comment
+    policy action([:update, :destroy]) do
+      authorize_if relates_to_actor_via(:user)
     end
   end
 
@@ -59,6 +73,8 @@ defmodule Petitionu.Post.Comment do
       public? true
     end
 
-    belongs_to :petition, Petitionu.Post.Petition
+    belongs_to :petition, Petitionu.Post.Petition do
+      public? true
+    end
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -408,12 +408,11 @@ Enum.each(comments_data, fn data ->
     case Ash.read_one!(existing_comment_query, authorize?: false) do
       nil ->
         Post.Comment
-        |> Ash.Changeset.for_create(:create, %{
+        |> Ash.Seed.seed!(%{
           text: data.message,
           petition_id: petition.id,
           user_id: user.id
         })
-        |> Ash.create!(authorize?: false)
 
       _ ->
         :ok

--- a/test/petitionu/post/comment_test.exs
+++ b/test/petitionu/post/comment_test.exs
@@ -1,0 +1,164 @@
+defmodule Petitionu.Post.CommentTest do
+  use Petitionu.DataCase, async: false
+
+  alias Petitionu.Accounts.Organization
+  alias Petitionu.Accounts.User
+  alias Petitionu.Post.Category
+  alias Petitionu.Post.Comment
+  alias Petitionu.Post.Petition
+
+  setup do
+    organization =
+      Organization
+      |> Ash.Changeset.for_create(:create, %{
+        name: "Test University",
+        description: "A test university",
+        domain: "test.edu",
+        allow_public_signatures: true
+      })
+      |> Ash.create!(authorize?: false)
+
+    category =
+      Category
+      |> Ash.Changeset.for_create(:create, %{
+        name: "Academic",
+        description: "Academic petitions",
+        organization_id: organization.id
+      })
+      |> Ash.create!(authorize?: false)
+
+    user = create_user("alice@example.com")
+    other_user = create_user("bob@example.com")
+
+    petition =
+      Petition
+      |> Ash.Seed.seed!(%{
+        title: "Test petition",
+        description: "A petition used by comment tests",
+        goal: 100,
+        status: :open,
+        user_id: user.id,
+        category_id: category.id
+      })
+
+    %{user: user, other_user: other_user, petition: petition}
+  end
+
+  defp create_user(email) do
+    User
+    |> Ash.Changeset.for_create(:register_with_password, %{
+      email: email,
+      password: "password123",
+      password_confirmation: "password123"
+    })
+    |> Ash.create!(authorize?: false)
+  end
+
+  defp create_comment(text, petition, user) do
+    Comment
+    |> Ash.Changeset.for_create(:create, %{text: text, petition_id: petition.id}, actor: user)
+    |> Ash.create!(actor: user)
+  end
+
+  describe "create" do
+    test "sets user_id from the authenticated actor", %{user: user, petition: petition} do
+      comment = create_comment("Love this!", petition, user)
+
+      assert comment.user_id == user.id
+      assert comment.petition_id == petition.id
+      assert comment.text == "Love this!"
+    end
+
+    test "rejects a client-supplied user_id", %{
+      user: user,
+      other_user: other_user,
+      petition: petition
+    } do
+      # The action no longer declares a user_id argument, so a spoofed value
+      # is rejected instead of being honored.
+      assert_raise Ash.Error.Invalid, ~r/user_id/, fn ->
+        Comment
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            text: "Spoofed author",
+            petition_id: petition.id,
+            user_id: other_user.id
+          },
+          actor: user
+        )
+        |> Ash.create!(actor: user)
+      end
+    end
+
+    test "accepts a petition_id of a petition whose id is a uuid_v7",
+         %{user: user, petition: petition} do
+      # Petition.id is a uuid_v7; the petition_id argument must cast it
+      comment = create_comment("uuid_v7 petition id works", petition, user)
+
+      assert comment.petition_id == petition.id
+    end
+
+    test "is forbidden without an authenticated actor", %{petition: petition} do
+      changeset =
+        Comment
+        |> Ash.Changeset.for_create(:create, %{text: "anon", petition_id: petition.id})
+
+      assert_raise Ash.Error.Forbidden, fn ->
+        Ash.create!(changeset)
+      end
+    end
+  end
+
+  describe "update/destroy" do
+    test "allows the author to update and destroy their comment",
+         %{user: user, petition: petition} do
+      comment = create_comment("original", petition, user)
+
+      updated =
+        comment
+        |> Ash.Changeset.for_update(:update, %{text: "edited"})
+        |> Ash.update!(actor: user)
+
+      assert updated.text == "edited"
+
+      Ash.destroy!(updated, actor: user)
+
+      require Ash.Query
+      assert Ash.read!(Ash.Query.filter(Comment, id == ^updated.id)) == []
+    end
+
+    test "forbids a non-author from updating",
+         %{user: user, other_user: other_user, petition: petition} do
+      comment = create_comment("original", petition, user)
+
+      assert_raise Ash.Error.Forbidden, fn ->
+        comment
+        |> Ash.Changeset.for_update(:update, %{text: "hacked"})
+        |> Ash.update!(actor: other_user)
+      end
+    end
+
+    test "forbids a non-author from destroying",
+         %{user: user, other_user: other_user, petition: petition} do
+      comment = create_comment("original", petition, user)
+
+      assert_raise Ash.Error.Forbidden, fn ->
+        Ash.destroy!(comment, actor: other_user)
+      end
+    end
+  end
+
+  describe "read" do
+    test "comments are readable without an authenticated actor",
+         %{user: user, petition: petition} do
+      comment = create_comment("public comment", petition, user)
+
+      fetched = Ash.get!(Comment, comment.id)
+
+      assert fetched.id == comment.id
+      assert fetched.user_id == user.id
+      assert fetched.text == "public comment"
+    end
+  end
+end


### PR DESCRIPTION
Closes #1 — comment creation was dead (the page's form had no submit handler) and, backstage, `Comment.create` trusted a client-supplied `user_id`, letting anyone impersonate another author.

## Backend (`lib/petitionu/post/comment.ex`)

- **Author spoofing closed:** removed `argument :user_id` from the `create` action and replaced `manage_relationship(:user_id, :user, ...)` with `change relate_actor(:user)` — the authenticated actor becomes the comment author. A client-supplied `user_id` is now rejected outright ("No such input `user_id`") instead of honored.
- **Type alignment:** `argument :petition_id` was `:uuid` while `Petition.id` is `uuid_v7`; aligned to `:uuid_v7` (proven by test — a comment creates successfully against a uuid_v7 petition id).
- **Authorization hole closed:** added `authorizers: [Ash.Policy.Authorizer]` with policies mirroring the existing `Petition` resource:
  - read → `authorize_if always()` (comments are public content)
  - create → `authorize_if actor_present()`
  - update/destroy → `authorize_if relates_to_actor_via(:user)` (owner-only)
- **Deliberately not included (future work):** enforcement of the petition's `allow_comments` flag — posting on an `allow_comments: false` petition is still permitted. Worth a follow-up validation/policy pass.

## Frontend (`assets/js/pages/petition-index-page.tsx`)

- The "Post Comment" form was a dead `<form>`; it now submits via the generated `createComment` RPC (`{ input: { text, petitionId }, headers: buildCSRFHeaders() }`), shows inline errors, disables the button while pending, invalidates `['petition', id]` on success, and clears the textarea.
- Petition query now requests `comments: ["id", "sentiment", "text", { user: ["firstName", "lastName"] }]` — real React keys and real author names, with an "Anon User" fallback when a comment has no user.
- Removed the vestigial, unfiltered `getUsers` fetch from this page (it pulled **all users' emails** through the public API and its result was never rendered).
- No redesign; sign/sidebar logic untouched.

Also regenerated the Ash TypeScript client via `mix ash_typescript.codegen` (the only way to keep `CreateCommentInput` correct — `userId` removed, `petitionId: UUIDv7`).

## Verification (honest state)

**Test-verified** (`test/petitionu/post/comment_test.exs`, 8 tests; full suite **13/13 green** via `mix precommit`):
- create sets `user_id` from the authenticated actor (`Ash.create!(..., actor: user)`)
- a spoofed client `user_id` is rejected
- unauthenticated create raises `Ash.Error.Forbidden`
- non-owner update and destroy raise `Ash.Error.Forbidden`; owner can update/destroy
- comments are readable with no actor
- `petition_id` accepts a uuid_v7 petition id (cast proof)

**Typecheck-only:** the React page wiring (`bunx tsc --noEmit` clean, exit 0). No browser-level E2E test was run for the form — the UI path is verified by types and by the backend action tests, not a live click-through.