### PR TITLE
fix(security): gate sensitive user fields behind field policies

### DIFF
--- a/assets/js/ash_rpc.ts
+++ b/assets/js/ash_rpc.ts
@@ -707,7 +707,7 @@ export async function validateGetUsers(
 
 
 export type SetUserRoleInput = {
-  role?: "admin" | "professor" | "student";
+  role?: "admin" | "professor" | "student" | "superadmin";
 };
 
 export type SetUserRoleFields = UnifiedFieldSelection<UserResourceSchema>[];

--- a/assets/js/ash_types.ts
+++ b/assets/js/ash_types.ts
@@ -97,7 +97,7 @@ export type UserResourceSchema = {
   lastName: string | null;
   email: string;
   graduationYear: number | null;
-  role: "admin" | "professor" | "student";
+  role: "admin" | "professor" | "student" | "superadmin";
   insertedAt: UtcDateTimeUsec;
   updatedAt: UtcDateTimeUsec;
   numPetitions: number;
@@ -120,7 +120,7 @@ export type UserAttributesOnlySchema = {
   lastName: string | null;
   email: string;
   graduationYear: number | null;
-  role: "admin" | "professor" | "student";
+  role: "admin" | "professor" | "student" | "superadmin";
   insertedAt: UtcDateTimeUsec;
   updatedAt: UtcDateTimeUsec;
 };
@@ -578,9 +578,9 @@ export type UserFilterInput = {
   };
 
   role?: {
-    eq?: "admin" | "professor" | "student";
-    notEq?: "admin" | "professor" | "student";
-    in?: Array<"admin" | "professor" | "student">;
+    eq?: "admin" | "professor" | "student" | "superadmin";
+    notEq?: "admin" | "professor" | "student" | "superadmin";
+    in?: Array<"admin" | "professor" | "student" | "superadmin">;
   };
 
   insertedAt?: {

--- a/lib/petitionu/accounts/user.ex
+++ b/lib/petitionu/accounts/user.ex
@@ -59,6 +59,40 @@ defmodule Petitionu.Accounts.User do
     repo Petitionu.Repo
   end
 
+  field_policies do
+    # Sensitive profile fields are readable only by the user themself
+    # (actor(:id) == id). Anonymous visitors and other users get
+    # %Ash.ForbiddenField{} (or a null) for these fields instead.
+    #
+    # AshAuthentication internal interactions (sign in, password lookup,
+    # subject-based actor loading) are exempted via the same check that backs
+    # the action-level bypass below. The exemption is evaluated when field
+    # visibility is decided (with the real query context), so internal reads
+    # still select these fields; `get_by_subject` additionally opts out of the
+    # post-read scrub via the `internal?` private context, so the loaded actor
+    # record keeps its `role` intact for role-based authorization checks.
+    field_policy [:email, :role, :graduation_year] do
+      authorize_if {AshAuthentication.Checks.AshAuthenticationInteraction, []}
+      authorize_if expr(id == ^actor(:id))
+    end
+
+    # Stats aggregates/calculations are only visible to the user themself.
+    field_policy [
+      :num_petitions,
+      :num_signed,
+      :num_petition_signees,
+      :total_petition_signatures
+    ] do
+      authorize_if {AshAuthentication.Checks.AshAuthenticationInteraction, []}
+      authorize_if expr(id == ^actor(:id))
+    end
+
+    # All remaining fields (first_name, last_name, timestamps, ...) are publicly readable.
+    field_policy :* do
+      authorize_if always()
+    end
+  end
+
   typescript do
     type_name "User"
   end
@@ -99,6 +133,17 @@ defmodule Petitionu.Accounts.User do
       argument :subject, :string, allow_nil?: false
       get? true
       prepare AshAuthentication.Preparations.FilterBySubject
+
+      # The record loaded here becomes the request actor (via
+      # AshAuthentication.subject_to_user/2), and its `role` drives
+      # authorization checks (e.g. `set_role` requires an admin actor). Keep
+      # its fields intact by opting out of field-level scrubbing as a second
+      # line of defense on top of the `AshAuthenticationInteraction` field
+      # policy checks. This action is not exposed via RPC or AshJsonApi
+      # (domains: []), and the internal? context is never settable by clients.
+      prepare fn query, _ ->
+        Ash.Query.set_context(query, %{private: %{internal?: true}})
+      end
     end
 
     update :change_password do
@@ -310,9 +355,12 @@ defmodule Petitionu.Accounts.User do
       authorize_if actor_attribute_equals(:role, :admin)
     end
 
-    # REMOVE LATER BAD SECURITY
+    # Anyone may read user records. Non-sensitive fields (e.g. first_name,
+    # last_name) are public so the UI can render author display names for
+    # unauthenticated visitors; sensitive fields are gated by the field
+    # policies below.
     policy action_type(:read) do
-      description "Allow reading user data if not authenticated"
+      description "Allow reading user data; sensitive fields are gated by field policies"
       authorize_if always()
     end
   end
@@ -341,6 +389,9 @@ defmodule Petitionu.Accounts.User do
 
     attribute :student_id, :string do
       allow_nil? true
+      # Student IDs are never exposed over public interfaces (RPC/client),
+      # so keep them private.
+      public? false
     end
 
     attribute :graduation_year, :integer do

--- a/lib/petitionu/accounts/user.ex
+++ b/lib/petitionu/accounts/user.ex
@@ -60,23 +60,13 @@ defmodule Petitionu.Accounts.User do
   end
 
   field_policies do
-    # Sensitive profile fields are readable only by the user themself
-    # (actor(:id) == id). Anonymous visitors and other users get
-    # %Ash.ForbiddenField{} (or a null) for these fields instead.
-    #
-    # AshAuthentication internal interactions (sign in, password lookup,
-    # subject-based actor loading) are exempted via the same check that backs
-    # the action-level bypass below. The exemption is evaluated when field
-    # visibility is decided (with the real query context), so internal reads
-    # still select these fields; `get_by_subject` additionally opts out of the
-    # post-read scrub via the `internal?` private context, so the loaded actor
-    # record keeps its `role` intact for role-based authorization checks.
     field_policy [:email, :role, :graduation_year] do
       authorize_if {AshAuthentication.Checks.AshAuthenticationInteraction, []}
       authorize_if expr(id == ^actor(:id))
+      authorize_if actor_attribute_equals(:role, :superadmin)
+      authorize_if expr(organization_id == ^actor(:organization_id) and ^actor(:role) == :admin)
     end
 
-    # Stats aggregates/calculations are only visible to the user themself.
     field_policy [
       :num_petitions,
       :num_signed,
@@ -85,9 +75,10 @@ defmodule Petitionu.Accounts.User do
     ] do
       authorize_if {AshAuthentication.Checks.AshAuthenticationInteraction, []}
       authorize_if expr(id == ^actor(:id))
+      authorize_if actor_attribute_equals(:role, :superadmin)
+      authorize_if expr(organization_id == ^actor(:organization_id) and ^actor(:role) == :admin)
     end
 
-    # All remaining fields (first_name, last_name, timestamps, ...) are publicly readable.
     field_policy :* do
       authorize_if always()
     end
@@ -134,13 +125,6 @@ defmodule Petitionu.Accounts.User do
       get? true
       prepare AshAuthentication.Preparations.FilterBySubject
 
-      # The record loaded here becomes the request actor (via
-      # AshAuthentication.subject_to_user/2), and its `role` drives
-      # authorization checks (e.g. `set_role` requires an admin actor). Keep
-      # its fields intact by opting out of field-level scrubbing as a second
-      # line of defense on top of the `AshAuthenticationInteraction` field
-      # policy checks. This action is not exposed via RPC or AshJsonApi
-      # (domains: []), and the internal? context is never settable by clients.
       prepare fn query, _ ->
         Ash.Query.set_context(query, %{private: %{internal?: true}})
       end
@@ -282,6 +266,18 @@ defmodule Petitionu.Accounts.User do
     update :set_role do
       description "Admin action to set a user's role"
       accept [:role]
+      require_atomic? false
+
+      validate fn changeset, context ->
+        requested_role = Ash.Changeset.get_attribute(changeset, :role)
+        actor_role = context.actor && context.actor.role
+
+        if requested_role == :superadmin and actor_role != :superadmin do
+          {:error, "only a superadmin can assign the superadmin role"}
+        else
+          :ok
+        end
+      end
     end
 
     update :reset_password_with_token do
@@ -353,14 +349,10 @@ defmodule Petitionu.Accounts.User do
     # Only admins can set user roles
     policy action(:set_role) do
       authorize_if actor_attribute_equals(:role, :admin)
+      authorize_if actor_attribute_equals(:role, :superadmin)
     end
 
-    # Anyone may read user records. Non-sensitive fields (e.g. first_name,
-    # last_name) are public so the UI can render author display names for
-    # unauthenticated visitors; sensitive fields are gated by the field
-    # policies below.
     policy action_type(:read) do
-      description "Allow reading user data; sensitive fields are gated by field policies"
       authorize_if always()
     end
   end
@@ -389,8 +381,6 @@ defmodule Petitionu.Accounts.User do
 
     attribute :student_id, :string do
       allow_nil? true
-      # Student IDs are never exposed over public interfaces (RPC/client),
-      # so keep them private.
       public? false
     end
 
@@ -400,7 +390,7 @@ defmodule Petitionu.Accounts.User do
     end
 
     attribute :role, :atom do
-      constraints one_of: [:student, :professor, :admin]
+      constraints one_of: [:student, :professor, :admin, :superadmin]
       default :student
       allow_nil? false
       public? true

--- a/test/petitionu/accounts/user_test.exs
+++ b/test/petitionu/accounts/user_test.exs
@@ -2,10 +2,17 @@ defmodule Petitionu.Accounts.UserTest do
   use Petitionu.DataCase, async: true
 
   alias Petitionu.Accounts
+  alias Petitionu.Accounts.Organization
 
   import Ash.Query
 
   @password "password123"
+
+  defp create_organization! do
+    Organization
+    |> Ash.Changeset.for_create(:create, %{name: "Test University"})
+    |> Ash.create!(authorize?: false)
+  end
 
   defp create_user!(attrs) do
     attrs = Map.merge(%{first_name: "Test", last_name: "User", role: :student}, Map.new(attrs))
@@ -21,7 +28,14 @@ defmodule Petitionu.Accounts.UserTest do
 
     Ash.Seed.update!(
       user,
-      Map.take(attrs, [:first_name, :last_name, :student_id, :graduation_year, :role])
+      Map.take(attrs, [
+        :first_name,
+        :last_name,
+        :student_id,
+        :graduation_year,
+        :role,
+        :organization_id
+      ])
     )
   end
 
@@ -49,11 +63,9 @@ defmodule Petitionu.Accounts.UserTest do
       anonymous_view = Enum.find(users, &(&1.id == other.id))
       refute is_nil(anonymous_view)
 
-      # Public display fields stay visible to anonymous visitors
       assert anonymous_view.first_name == "Jane"
       assert anonymous_view.last_name == "Doe"
 
-      # Sensitive fields are hidden from anonymous visitors
       assert %Ash.ForbiddenField{} = anonymous_view.email
       assert %Ash.ForbiddenField{} = anonymous_view.role
       assert %Ash.ForbiddenField{} = anonymous_view.graduation_year
@@ -62,9 +74,6 @@ defmodule Petitionu.Accounts.UserTest do
       assert %Ash.ForbiddenField{} = anonymous_view.num_petition_signees
       assert %Ash.ForbiddenField{} = anonymous_view.total_petition_signatures
 
-      # student_id is a private (non-public) attribute: it is never included
-      # in public interfaces (RPC responses / generated client), even though
-      # plain Ash reads still see it.
       public_attrs =
         Accounts.User
         |> Ash.Resource.Info.public_attributes()
@@ -136,21 +145,16 @@ defmodule Petitionu.Accounts.UserTest do
       student = create_user!(email: "student-role@example.com", role: :student)
       target = create_user!(email: "target-role@example.com", role: :student)
 
-      # A non-admin actor is forbidden from changing roles
       assert {:error, %Ash.Error.Forbidden{}} =
                target
                |> Ash.Changeset.for_update(:set_role, %{role: :admin}, actor: student)
                |> Ash.update(actor: student)
 
-      # The updated record, returned to an admin acting on another user,
-      # has role scrubbed (role is only visible to the user themself), so
-      # verify the write succeeded by reading the target as the target.
       assert {:ok, %Accounts.User{} = updated} =
                target
                |> Ash.Changeset.for_update(:set_role, %{role: :professor}, actor: admin)
                |> Ash.update(actor: admin)
 
-      # The target's own read now shows the new role.
       own_read =
         Accounts.User
         |> Ash.Query.for_read(:read_users)
@@ -159,11 +163,98 @@ defmodule Petitionu.Accounts.UserTest do
 
       assert own_read.role == :professor
 
-      # Anonymous actors are forbidden as well
+      assert {:error, %Ash.Error.Invalid{}} =
+               target
+               |> Ash.Changeset.for_update(:set_role, %{role: :superadmin}, actor: admin)
+               |> Ash.update(actor: admin)
+
+      superadmin = create_user!(email: "global-role@example.com", role: :superadmin)
+
+      assert {:ok, _updated} =
+               target
+               |> Ash.Changeset.for_update(:set_role, %{role: :admin}, actor: superadmin)
+               |> Ash.update(actor: superadmin)
+
       assert {:error, %Ash.Error.Forbidden{}} =
                target
                |> Ash.Changeset.for_update(:set_role, %{role: :admin})
                |> Ash.update(actor: nil)
+    end
+
+    test "an admin can read sensitive fields for users in the same organization" do
+      organization = create_organization!()
+
+      admin =
+        create_user!(
+          email: "org-admin@example.com",
+          role: :admin,
+          organization_id: organization.id
+        )
+
+      target =
+        create_user!(
+          email: "org-target@example.com",
+          role: :student,
+          organization_id: organization.id
+        )
+
+      target_view =
+        Accounts.User
+        |> for_read(:read_by_id, %{id: target.id, include_stats: true})
+        |> Ash.read_one!(actor: admin)
+
+      assert to_string(target_view.email) == "org-target@example.com"
+      assert target_view.role == :student
+      assert target_view.num_petitions == 0
+    end
+
+    test "an admin cannot read sensitive fields outside their organization" do
+      admin_org = create_organization!()
+      other_org = create_organization!()
+
+      admin =
+        create_user!(
+          email: "scoped-admin@example.com",
+          role: :admin,
+          organization_id: admin_org.id
+        )
+
+      target =
+        create_user!(
+          email: "other-org@example.com",
+          role: :student,
+          organization_id: other_org.id
+        )
+
+      target_view =
+        Accounts.User
+        |> for_read(:read_by_id, %{id: target.id, include_stats: true})
+        |> Ash.read_one!(actor: admin)
+
+      assert %Ash.ForbiddenField{} = target_view.email
+      assert %Ash.ForbiddenField{} = target_view.role
+      assert %Ash.ForbiddenField{} = target_view.num_petitions
+    end
+
+    test "a superadmin can read sensitive fields across organizations" do
+      organization = create_organization!()
+      superadmin = create_user!(email: "global-admin@example.com", role: :superadmin)
+
+      target =
+        create_user!(
+          email: "global-target@example.com",
+          role: :student,
+          organization_id: organization.id
+        )
+
+      target_view =
+        Accounts.User
+        |> for_read(:read_by_id, %{id: target.id, include_stats: true})
+        |> Ash.read_one!(actor: superadmin)
+
+      assert to_string(target_view.email) == "global-target@example.com"
+      assert target_view.role == :student
+      assert target_view.num_petitions == 0
     end
   end
 
@@ -182,9 +273,6 @@ defmodule Petitionu.Accounts.UserTest do
       assert signed_in.id == user.id
       refute is_nil(signed_in.__metadata__.token)
 
-      # The record returned by the sign-in action itself has its sensitive
-      # fields scrubbed (the actor that would authorize them isn't present
-      # yet), so clients must use `getMe` to load the full profile.
       assert %Ash.ForbiddenField{} = signed_in.email
       assert %Ash.ForbiddenField{} = signed_in.role
     end
@@ -192,12 +280,6 @@ defmodule Petitionu.Accounts.UserTest do
     test "get_by_email internal read (used by password reset) keeps email/role" do
       user = create_user!(email: "reset@example.com", first_name: "Reset", last_name: "Me")
 
-      # Mirrors AshAuthentication.Strategy.Password.RequestPasswordReset.run/5,
-      # which reads the user with `private.ash_authentication?: true` set.
-      # The private context is only set by AshAuthentication's own internals
-      # (the public RPC pipeline forwards only `shared` context), so this
-      # exemption cannot be triggered by anonymous clients; their
-      # get_user_by_email calls get these fields scrubbed.
       assert {:ok, found} =
                Accounts.User
                |> Ash.Query.new()

--- a/test/petitionu/accounts/user_test.exs
+++ b/test/petitionu/accounts/user_test.exs
@@ -1,0 +1,233 @@
+defmodule Petitionu.Accounts.UserTest do
+  use Petitionu.DataCase, async: true
+
+  alias Petitionu.Accounts
+
+  import Ash.Query
+
+  @password "password123"
+
+  defp create_user!(attrs) do
+    attrs = Map.merge(%{first_name: "Test", last_name: "User", role: :student}, Map.new(attrs))
+
+    user =
+      Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: attrs.email,
+        password: @password,
+        password_confirmation: @password
+      })
+      |> Ash.create!(authorize?: false)
+
+    Ash.Seed.update!(
+      user,
+      Map.take(attrs, [:first_name, :last_name, :student_id, :graduation_year, :role])
+    )
+  end
+
+  describe "reading users" do
+    test "(a) anonymous read of users succeeds and returns first/last name but not email/role/stats" do
+      other =
+        create_user!(
+          email: "other-user@example.com",
+          first_name: "Jane",
+          last_name: "Doe",
+          student_id: "S12345",
+          graduation_year: 2025,
+          role: :admin
+        )
+
+      users =
+        Accounts.User
+        |> for_read(:read_users)
+        |> load([:num_petitions, :num_signed, :num_petition_signees])
+        |> load(:total_petition_signatures)
+        |> Ash.read!(actor: nil)
+
+      assert users != []
+
+      anonymous_view = Enum.find(users, &(&1.id == other.id))
+      refute is_nil(anonymous_view)
+
+      # Public display fields stay visible to anonymous visitors
+      assert anonymous_view.first_name == "Jane"
+      assert anonymous_view.last_name == "Doe"
+
+      # Sensitive fields are hidden from anonymous visitors
+      assert %Ash.ForbiddenField{} = anonymous_view.email
+      assert %Ash.ForbiddenField{} = anonymous_view.role
+      assert %Ash.ForbiddenField{} = anonymous_view.graduation_year
+      assert %Ash.ForbiddenField{} = anonymous_view.num_petitions
+      assert %Ash.ForbiddenField{} = anonymous_view.num_signed
+      assert %Ash.ForbiddenField{} = anonymous_view.num_petition_signees
+      assert %Ash.ForbiddenField{} = anonymous_view.total_petition_signatures
+
+      # student_id is a private (non-public) attribute: it is never included
+      # in public interfaces (RPC responses / generated client), even though
+      # plain Ash reads still see it.
+      public_attrs =
+        Accounts.User
+        |> Ash.Resource.Info.public_attributes()
+        |> Enum.map(& &1.name)
+
+      refute :student_id in public_attrs
+      assert :hashed_password not in public_attrs
+    end
+
+    test "(b) a user reading their own record sees email/role/stats" do
+      user =
+        create_user!(
+          email: "self-owner@example.com",
+          first_name: "Ada",
+          last_name: "Lovelace",
+          student_id: "S777",
+          graduation_year: 2026
+        )
+
+      own_view =
+        Accounts.User
+        |> for_read(:read_users)
+        |> load([:num_petitions, :num_signed, :num_petition_signees])
+        |> load(:total_petition_signatures)
+        |> Ash.read!(actor: user)
+        |> Enum.find(&(&1.id == user.id))
+
+      assert own_view.first_name == "Ada"
+      assert own_view.last_name == "Lovelace"
+      assert to_string(own_view.email) == "self-owner@example.com"
+      assert own_view.role == :student
+      assert own_view.student_id == "S777"
+      assert own_view.graduation_year == 2026
+      assert own_view.num_petitions == 0
+      assert own_view.num_signed == 0
+      assert own_view.num_petition_signees == 0
+    end
+
+    test "(c) reading another user's record by id hides email/role/stats" do
+      actor = create_user!(email: "reader@example.com", first_name: "Reader", last_name: "One")
+
+      other =
+        create_user!(
+          email: "target@example.com",
+          first_name: "Target",
+          last_name: "Two",
+          role: :professor
+        )
+
+      other_view =
+        Accounts.User
+        |> for_read(:read_by_id, %{id: other.id, include_stats: true})
+        |> Ash.read_one!(actor: actor)
+
+      refute is_nil(other_view)
+      assert other_view.first_name == "Target"
+      assert other_view.last_name == "Two"
+
+      assert %Ash.ForbiddenField{} = other_view.email
+      assert %Ash.ForbiddenField{} = other_view.role
+      assert %Ash.ForbiddenField{} = other_view.num_petitions
+      assert %Ash.ForbiddenField{} = other_view.num_signed
+      assert %Ash.ForbiddenField{} = other_view.num_petition_signees
+      assert %Ash.ForbiddenField{} = other_view.total_petition_signatures
+    end
+
+    test "(d) set_role still requires an admin actor" do
+      admin = create_user!(email: "admin-role@example.com", role: :admin)
+      student = create_user!(email: "student-role@example.com", role: :student)
+      target = create_user!(email: "target-role@example.com", role: :student)
+
+      # A non-admin actor is forbidden from changing roles
+      assert {:error, %Ash.Error.Forbidden{}} =
+               target
+               |> Ash.Changeset.for_update(:set_role, %{role: :admin}, actor: student)
+               |> Ash.update(actor: student)
+
+      # The updated record, returned to an admin acting on another user,
+      # has role scrubbed (role is only visible to the user themself), so
+      # verify the write succeeded by reading the target as the target.
+      assert {:ok, %Accounts.User{} = updated} =
+               target
+               |> Ash.Changeset.for_update(:set_role, %{role: :professor}, actor: admin)
+               |> Ash.update(actor: admin)
+
+      # The target's own read now shows the new role.
+      own_read =
+        Accounts.User
+        |> Ash.Query.for_read(:read_users)
+        |> Ash.read!(actor: target)
+        |> Enum.find(&(&1.id == updated.id))
+
+      assert own_read.role == :professor
+
+      # Anonymous actors are forbidden as well
+      assert {:error, %Ash.Error.Forbidden{}} =
+               target
+               |> Ash.Changeset.for_update(:set_role, %{role: :admin})
+               |> Ash.update(actor: nil)
+    end
+  end
+
+  describe "ash_authentication internal flows" do
+    test "sign_in_with_password still works (internal reads bypass field policies)" do
+      user = create_user!(email: "signin@example.com", first_name: "Sign", last_name: "In")
+
+      assert {:ok, signed_in} =
+               Accounts.User
+               |> Ash.Query.for_read(:sign_in_with_password, %{
+                 email: "signin@example.com",
+                 password: @password
+               })
+               |> Ash.read_one()
+
+      assert signed_in.id == user.id
+      refute is_nil(signed_in.__metadata__.token)
+
+      # The record returned by the sign-in action itself has its sensitive
+      # fields scrubbed (the actor that would authorize them isn't present
+      # yet), so clients must use `getMe` to load the full profile.
+      assert %Ash.ForbiddenField{} = signed_in.email
+      assert %Ash.ForbiddenField{} = signed_in.role
+    end
+
+    test "get_by_email internal read (used by password reset) keeps email/role" do
+      user = create_user!(email: "reset@example.com", first_name: "Reset", last_name: "Me")
+
+      # Mirrors AshAuthentication.Strategy.Password.RequestPasswordReset.run/5,
+      # which reads the user with `private.ash_authentication?: true` set.
+      # The private context is only set by AshAuthentication's own internals
+      # (the public RPC pipeline forwards only `shared` context), so this
+      # exemption cannot be triggered by anonymous clients; their
+      # get_user_by_email calls get these fields scrubbed.
+      assert {:ok, found} =
+               Accounts.User
+               |> Ash.Query.new()
+               |> Ash.Query.set_context(%{private: %{ash_authentication?: true}})
+               |> Ash.Query.for_read(:get_by_email, %{email: "reset@example.com"})
+               |> Ash.read_one()
+
+      assert found.id == user.id
+      assert to_string(found.email) == "reset@example.com"
+      assert found.role == :student
+    end
+
+    test "actor loaded via subject_to_user keeps email/role (drives role-based policies)" do
+      admin =
+        create_user!(
+          email: "admindata@example.com",
+          first_name: "Admin",
+          last_name: "Data",
+          role: :admin
+        )
+
+      assert {:ok, loaded} =
+               AshAuthentication.subject_to_user(
+                 AshAuthentication.user_to_subject(admin),
+                 Accounts.User
+               )
+
+      assert loaded.id == admin.id
+      assert loaded.role == :admin
+      assert to_string(loaded.email) == "admindata@example.com"
+    end
+  end
+end

--- a/test/petitionu_web/controllers/ash_typescript_rpc_controller_test.exs
+++ b/test/petitionu_web/controllers/ash_typescript_rpc_controller_test.exs
@@ -26,9 +26,6 @@ defmodule PetitionuWeb.AshTypescriptRpcControllerTest do
       rpc_view = Enum.find(users, &(&1["firstName"] == "RPC"))
       refute is_nil(rpc_view)
       assert rpc_view["lastName"] == "User"
-      # The read succeeds; the denied email field is emitted as null, so the
-      # frontend's `getUsers({fields: [\"firstName\", \"lastName\", \"email\"]})`
-      # call in petition-index-page.tsx does NOT error.
       assert rpc_view["email"] == nil
     end
   end

--- a/test/petitionu_web/controllers/ash_typescript_rpc_controller_test.exs
+++ b/test/petitionu_web/controllers/ash_typescript_rpc_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule PetitionuWeb.AshTypescriptRpcControllerTest do
+  use PetitionuWeb.ConnCase, async: true
+
+  alias Petitionu.Accounts
+
+  describe "get_users RPC" do
+    test "anonymous getUsers succeeds and returns email as null for other users", %{conn: conn} do
+      _user =
+        Accounts.User
+        |> Ash.Changeset.for_create(:register_with_password, %{
+          email: "rpc-get-users@example.com",
+          password: "password123",
+          password_confirmation: "password123"
+        })
+        |> Ash.create!(authorize?: false)
+        |> Ash.Seed.update!(%{first_name: "RPC", last_name: "User"})
+
+      conn =
+        post(conn, "/rpc/run", %{
+          "action" => "get_users",
+          "fields" => ["firstName", "lastName", "email"]
+        })
+
+      assert %{"success" => true, "data" => users} = json_response(conn, 200)
+
+      rpc_view = Enum.find(users, &(&1["firstName"] == "RPC"))
+      refute is_nil(rpc_view)
+      assert rpc_view["lastName"] == "User"
+      # The read succeeds; the denied email field is emitted as null, so the
+      # frontend's `getUsers({fields: [\"firstName\", \"lastName\", \"email\"]})`
+      # call in petition-index-page.tsx does NOT error.
+      assert rpc_view["email"] == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Restrict sensitive user data by organization and add a global `superadmin` role.

## Access rules

- Users can read their own sensitive fields.
- `admin` users can read sensitive fields for users in the same `organization_id`.
- `admin` users cannot read sensitive fields for users in another organization.
- `superadmin` users can read sensitive fields for users in any organization.
- Names and timestamps remain public.
- `student_id` remains private and is not exposed through generated client types.
- Authentication internals can still load the fields needed for sign-in, password reset, and actor authorization.

Sensitive fields include:

- `email`
- `role`
- `graduation_year`
- `num_petitions`
- `num_signed`
- `num_petition_signees`
- `total_petition_signatures`

Denied fields are returned as `null` by the RPC layer; the request still succeeds.

## Role management

The role union now includes `superadmin`. Existing admins can continue managing ordinary roles. Assigning the `superadmin` role requires an existing superadmin, and the `set_role` action is non-atomic because that guard is implemented as an Ash validation.

## Verification

- `mix precommit` passed: 16 tests
- `mix test test/petitionu/accounts/user_test.exs` passed: 10 tests
- `bunx tsc --noEmit` passed
- `mix ash.codegen --check` passed with no pending code generation
- Tests cover anonymous reads, self reads, same-organization admin reads, cross-organization denial, superadmin reads, role assignment, authentication internals, and the RPC response shape.

The PR comments and code explanations were shortened to keep the diff focused on behavior and tests.