### PR TITLE
[Global] Fix routing, auth leak, theme/CSS and SEO foundations (fixes #10)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,7 +2,6 @@
    https://tailwindcss.com/docs/configuration */
 
 /* Import Google Fonts */
-@import url("https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,400;0,700;1,400;1,700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap");
 
@@ -144,6 +143,9 @@
   --radius: 0.5rem;
 }
 
+/* shadcn/ui vars drive the React SPA via the `.dark` class. The daisyUI
+   `data-theme` blocks above drive the Phoenix auth pages via `data-theme`.
+   They coexist: the SPA never sets data-theme, auth pages never set .dark. */
 .dark {
   --background: oklch(0.18 0.02 160);
   --foreground: oklch(0.98 0.005 85);
@@ -172,7 +174,7 @@
 }
 
 @theme inline {
-  --font-sans: "Newsreader", "Geist Fallback";
+  --font-sans: "Geist", "Geist Fallback";
   --font-mono: "Geist Mono", "Geist Mono Fallback";
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/assets/js/app.tsx
+++ b/assets/js/app.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { BrowserRouter, Routes, Route } from "react-router-dom"
-import { Header } from "./components/header"
 import { HomePage } from "./pages/home-page"
 import PetitionIndexPage from "./pages/petition-index-page"
 import DashboardPage from "./pages/dashboard-page"
@@ -9,9 +8,12 @@ import CreatePetitionPage from "./pages/create-petition-page"
 import ClassroomsPage from "./pages/classrooms-page"
 import ClassroomDetailPage from "./pages/classroom-detail-page"
 import CreateClassroomPage from "./pages/create-classroom-page"
+import { NotFoundPage } from "./pages/not-found-page"
+import { Layout } from "./components/layout"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ErrorBoundary } from "../components/ui/error-boundary"
 import { AuthProvider } from "./contexts/auth-context"
+import { DEFAULT_PATH } from "@/lib/routes"
 
 // Create a client instance with proper configuration
 const queryClient = new QueryClient({
@@ -37,28 +39,26 @@ const queryClient = new QueryClient({
 })
 
 export const App = () => {
-  const defaultPath = "/ash-typescript"
+  const defaultPath = DEFAULT_PATH
 
   return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
           <BrowserRouter>
-            <div className="min-h-screen bg-gradient-to-br from-slate-50 to-orange-50">
-              <Header />
-              <main>
-                <Routes>
-                  <Route path={defaultPath} element={<HomePage />} />
-                  <Route path={`${defaultPath}/petitions`} element={<BrowsePetitionsPage />} />
-                  <Route path={`${defaultPath}/petitions/:id`} element={<PetitionIndexPage />} />
-                  <Route path={`${defaultPath}/create`} element={<CreatePetitionPage />} />
-                  <Route path={`${defaultPath}/dashboard`} element={<DashboardPage />} />
-                  <Route path={`${defaultPath}/classrooms`} element={<ClassroomsPage />} />
-                  <Route path={`${defaultPath}/classrooms/new`} element={<CreateClassroomPage />} />
-                  <Route path={`${defaultPath}/classrooms/:id`} element={<ClassroomDetailPage />} />
-                </Routes>
-              </main>
-            </div>
+            <Layout>
+              <Routes>
+                <Route path={defaultPath} element={<HomePage />} />
+                <Route path={`${defaultPath}/petitions`} element={<BrowsePetitionsPage />} />
+                <Route path={`${defaultPath}/petitions/:id`} element={<PetitionIndexPage />} />
+                <Route path={`${defaultPath}/create`} element={<CreatePetitionPage />} />
+                <Route path={`${defaultPath}/dashboard`} element={<DashboardPage />} />
+                <Route path={`${defaultPath}/classrooms`} element={<ClassroomsPage />} />
+                <Route path={`${defaultPath}/classrooms/new`} element={<CreateClassroomPage />} />
+                <Route path={`${defaultPath}/classrooms/:id`} element={<ClassroomDetailPage />} />
+                <Route path="*" element={<NotFoundPage />} />
+              </Routes>
+            </Layout>
           </BrowserRouter>
         </AuthProvider>
       </QueryClientProvider>

--- a/assets/js/components/footer.tsx
+++ b/assets/js/components/footer.tsx
@@ -1,0 +1,36 @@
+import { GraduationCap } from "lucide-react"
+import { Link } from "react-router-dom"
+import { ROUTES } from "@/lib/routes"
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border bg-card/50">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+          <Link to={ROUTES.home} className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-primary rounded-full flex items-center justify-center">
+              <GraduationCap className="w-4 h-4 text-primary-foreground" />
+            </div>
+            <span className="font-semibold text-foreground">PetitionU</span>
+          </Link>
+
+          <nav className="flex items-center gap-6 text-sm text-muted-foreground">
+            <Link to={ROUTES.petitions} className="hover:text-foreground transition-colors">
+              Browse Petitions
+            </Link>
+            <Link to={ROUTES.dashboard} className="hover:text-foreground transition-colors">
+              Dashboard
+            </Link>
+            <Link to={ROUTES.classrooms} className="hover:text-foreground transition-colors">
+              Classrooms
+            </Link>
+          </nav>
+
+          <p className="text-xs text-muted-foreground">
+            &copy; {new Date().getFullYear()} PetitionU
+          </p>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/assets/js/components/header.tsx
+++ b/assets/js/components/header.tsx
@@ -1,12 +1,13 @@
 import { GraduationCap, User } from "lucide-react"
 import { Link } from "react-router-dom"
+import { ROUTES } from "@/lib/routes"
 
 export function Header() {
   return (
     <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-50">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16 lg:h-20">
-          <Link to={"/ash-typescript/"}>
+          <Link to={ROUTES.home}>
             <div className="flex items-center gap-2">
               <div className="w-8 h-8 lg:w-10 lg:h-10 bg-primary rounded-full flex items-center justify-center">
                 <GraduationCap className="w-4 h-4 lg:w-5 lg:h-5 text-primary-foreground" />
@@ -17,19 +18,19 @@ export function Header() {
 
           <nav className="hidden md:flex items-center gap-8">
             <Link
-              to="/ash-typescript/dashboard"
+              to={ROUTES.dashboard}
               className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               Dashboard
             </Link>
             <Link
-              to={`/ash-typescript/petitions`}
+              to={ROUTES.petitions}
               className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               Browse Petitions
             </Link>
             <Link
-              to={`/ash-typescript/create`}
+              to={ROUTES.createPetition}
               className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               Start a Petition
@@ -41,7 +42,7 @@ export function Header() {
               <User className="w-5 h-5" />
             </button>
             <Link
-              to="/ash-typescript/create"
+              to={ROUTES.createPetition}
               className="bg-primary text-primary-foreground hover:bg-primary/90 p-2 rounded-md"
             >
               <span className="hidden sm:inline">Start a Petition</span>

--- a/assets/js/components/layout.tsx
+++ b/assets/js/components/layout.tsx
@@ -1,0 +1,12 @@
+import { Header } from "./header"
+import { Footer } from "./footer"
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-gradient-to-br from-slate-50 to-orange-50">
+      <Header />
+      <div className="flex-1">{children}</div>
+      <Footer />
+    </div>
+  )
+}

--- a/assets/js/features/classroom/classroom-card.tsx
+++ b/assets/js/features/classroom/classroom-card.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { CleanResource } from "@/lib/types"
 import { ClassroomResourceSchema } from "@/js/ash_rpc"
 import { useState } from "react"
+import { ROUTES } from "@/lib/routes"
 
 export type Classroom = CleanResource<ClassroomResourceSchema>
 
@@ -27,7 +28,7 @@ export function ClassroomCard({ classroom, isOwner = false, showJoinCode = false
   }
 
   return (
-    <Link to={`/ash-typescript/classrooms/${classroom.id}`}>
+    <Link to={ROUTES.classroom(classroom.id)}>
       <Card className="p-6 hover:shadow-lg transition-all duration-300 hover:border-primary/50">
         <div className="flex items-start justify-between mb-4">
           <div className="flex items-center gap-2">

--- a/assets/js/features/classroom/classroom-list.tsx
+++ b/assets/js/features/classroom/classroom-list.tsx
@@ -2,6 +2,7 @@ import { ClassroomCard, Classroom } from "./classroom-card"
 import { Plus } from "lucide-react"
 import { Link } from "react-router-dom"
 import { Button } from "@/components/ui/button"
+import { ROUTES } from "@/lib/routes"
 
 interface ClassroomListProps {
   classrooms: Classroom[]
@@ -21,7 +22,7 @@ export function ClassroomList({
       <div className="text-center py-12 bg-card rounded-lg border border-border">
         <p className="text-muted-foreground mb-4">{emptyMessage}</p>
         {showCreateButton && (
-          <Link to="/ash-typescript/classrooms/new">
+          <Link to={ROUTES.classroomNew}>
             <Button>
               <Plus className="w-4 h-4 mr-2" />
               Create Your First Classroom

--- a/assets/js/features/classroom/my-classrooms.tsx
+++ b/assets/js/features/classroom/my-classrooms.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { getMyClassrooms, buildCSRFHeaders, ClassroomResourceSchema } from "@/js/ash_rpc"
 import { CleanResource } from "@/lib/types"
+import { ROUTES } from "@/lib/routes"
 
 type Classroom = CleanResource<ClassroomResourceSchema>
 
@@ -86,7 +87,7 @@ export function MyClassrooms({ limit = 3, currentUserId }: MyClassroomsProps) {
           <GraduationCap className="w-5 h-5" />
           My Classrooms
         </h2>
-        <Link to="/ash-typescript/classrooms">
+        <Link to={ROUTES.classrooms}>
           <Button variant="ghost" size="sm">
             View All
             <ChevronRight className="w-4 h-4 ml-1" />
@@ -100,7 +101,7 @@ export function MyClassrooms({ limit = 3, currentUserId }: MyClassroomsProps) {
           <p className="text-sm text-muted-foreground mb-4">
             You haven't joined any classrooms yet
           </p>
-          <Link to="/ash-typescript/classrooms">
+          <Link to={ROUTES.classrooms}>
             <Button size="sm">Browse Classrooms</Button>
           </Link>
         </div>
@@ -109,7 +110,7 @@ export function MyClassrooms({ limit = 3, currentUserId }: MyClassroomsProps) {
           {displayClassrooms.map((classroom: Classroom) => (
             <Link
               key={classroom.id}
-              to={`/ash-typescript/classrooms/${classroom.id}`}
+              to={ROUTES.classroom(classroom.id)}
               className="block"
             >
               <div className="p-3 rounded-lg border border-border hover:border-primary/50 hover:bg-muted/50 transition-all">

--- a/assets/js/features/petition/petition-card.tsx
+++ b/assets/js/features/petition/petition-card.tsx
@@ -3,6 +3,7 @@ import { TrendingUp, User } from "lucide-react"
 import { Link } from "react-router-dom"
 import { PetitionResourceSchema } from "../../ash_rpc"
 import { Button } from "@/components/ui/button"
+import { ROUTES } from "@/lib/routes"
 
 type Petition = CleanResource<PetitionResourceSchema>
 
@@ -10,7 +11,7 @@ export function PetitionCard({ petition }: { petition: Petition }) {
   const progress = ((petition.signaturesCount ?? 0) / (petition.goal ?? 1)) * 100
 
   return (
-    <Link to={`/ash-typescript/petitions/${petition.id}`}>
+    <Link to={ROUTES.petition(petition.id)}>
       <div className="bg-card border border-border rounded-lg p-6 hover:shadow-lg transition-shadow duration-300">
         <div className="flex items-start justify-between mb-4">
           <span className="px-3 py-1 rounded-full text-xs font-medium bg-secondary text-secondary-foreground">
@@ -57,7 +58,7 @@ export function PetitionCard({ petition }: { petition: Petition }) {
           </div>
         </div>
 
-        <Link to={`/ash-typescript/petitions/${petition.id}`}>
+        <Link to={ROUTES.petition(petition.id)}>
           <Button className="w-full mt-6 bg-primary text-primary-foreground hover:bg-primary/90">
             Sign This Petition
           </Button>

--- a/assets/js/features/petition/petition-grid.tsx
+++ b/assets/js/features/petition/petition-grid.tsx
@@ -2,6 +2,7 @@ import { PetitionCard } from "./petition-card"
 import { PetitionResourceSchema } from "../../ash_rpc"
 import { CleanResource } from "@/lib/types"
 import { Button } from "@/components/ui/button"
+import { ROUTES } from "@/lib/routes"
 
 // Fallback mock data for when no petitions are available
 const mockPetitions: CleanResource<PetitionResourceSchema>[] = [
@@ -132,7 +133,7 @@ export function PetitionGrid({ petitions = mockPetitions }: PetitionGridProps) {
                 No petitions found. Be the first to start a petition!
               </p>
               <Button className="mt-4" asChild>
-                <a href="/ash-typescript/create">Start a Petition</a>
+                <a href={ROUTES.createPetition}>Start a Petition</a>
               </Button>
             </div>
           )}

--- a/assets/js/hooks/use-document-title.ts
+++ b/assets/js/hooks/use-document-title.ts
@@ -1,0 +1,7 @@
+import { useEffect } from "react"
+
+export function useDocumentTitle(title: string) {
+  useEffect(() => {
+    document.title = title ? `${title} · PetitionU` : "PetitionU"
+  }, [title])
+}

--- a/assets/js/lib/routes.ts
+++ b/assets/js/lib/routes.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_PATH = "/ash-typescript" as const
+
+export const ROUTES = {
+  home: DEFAULT_PATH,
+  petitions: `${DEFAULT_PATH}/petitions`,
+  petition: (id: string) => `${DEFAULT_PATH}/petitions/${id}`,
+  createPetition: `${DEFAULT_PATH}/create`,
+  createPetitionWithClassroom: (classroomId: string) =>
+    `${DEFAULT_PATH}/create?classroomId=${classroomId}`,
+  dashboard: `${DEFAULT_PATH}/dashboard`,
+  classrooms: `${DEFAULT_PATH}/classrooms`,
+  classroom: (id: string) => `${DEFAULT_PATH}/classrooms/${id}`,
+  classroomNew: `${DEFAULT_PATH}/classrooms/new`,
+  classroomEdit: (id: string) => `${DEFAULT_PATH}/classrooms/${id}/edit`,
+} as const

--- a/assets/js/pages/browse-petitions-page.tsx
+++ b/assets/js/pages/browse-petitions-page.tsx
@@ -21,6 +21,7 @@ import {
 } from "../ash_rpc"
 import { CleanResource } from "../../lib/types"
 import { useQuery } from "@tanstack/react-query"
+import { useDocumentTitle } from "../hooks/use-document-title"
 
 const SORT_OPTIONS = [
   { value: "trending", label: "Trending" },
@@ -122,6 +123,8 @@ function LoadingState() {
 }
 
 export default function BrowsePetitionsPage() {
+  useDocumentTitle("Browse Petitions")
+
   const [searchQuery, setSearchQuery] = useState("")
   const [selectedCategory, setSelectedCategory] = useState("All")
   const [sortBy, setSortBy] = useState("trending")

--- a/assets/js/pages/classroom-detail-page.tsx
+++ b/assets/js/pages/classroom-detail-page.tsx
@@ -28,6 +28,8 @@ import {
 import { MemberList } from "../features/classroom/member-list"
 import { PetitionCard } from "../features/petition/petition-card"
 import { useAuth } from "../contexts/auth-context"
+import { ROUTES } from "@/lib/routes"
+import { useDocumentTitle } from "../hooks/use-document-title"
 
 // Loading state component
 function ClassroomDetailLoadingState() {
@@ -154,6 +156,8 @@ export default function ClassroomDetailPage() {
     enabled: !!id,
   })
 
+  useDocumentTitle(classroomQuery?.data?.name ?? "Classroom")
+
   // Regenerate join code mutation
   const regenerateMutation = useMutation({
     mutationFn: async () => {
@@ -225,7 +229,7 @@ export default function ClassroomDetailPage() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
           <div className="text-center py-12">
             <p className="text-destructive">Error: {classroomQuery.error?.message}</p>
-            <Button onClick={() => navigate("/ash-typescript/classrooms")} className="mt-4">
+            <Button onClick={() => navigate(ROUTES.classrooms)} className="mt-4">
               Back to Classrooms
             </Button>
           </div>
@@ -245,7 +249,7 @@ export default function ClassroomDetailPage() {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
         {/* Back Link */}
         <Link
-          to="/ash-typescript/classrooms"
+          to={ROUTES.classrooms}
           className="inline-flex items-center text-muted-foreground hover:text-foreground mb-6 transition-colors"
         >
           <ArrowLeft className="w-4 h-4 mr-2" />
@@ -286,7 +290,7 @@ export default function ClassroomDetailPage() {
 
           {isProfessor && (
             <div className="flex items-center gap-2">
-              <Link to={`/ash-typescript/classrooms/${id}/edit`}>
+              <Link to={ROUTES.classroomEdit(id!)}>
                 <Button variant="outline">
                   <Settings className="w-4 h-4 mr-2" />
                   Settings
@@ -329,7 +333,7 @@ export default function ClassroomDetailPage() {
             <div className="flex items-center justify-between">
               <h2 className="text-xl font-semibold text-foreground">Petitions</h2>
               {(classroom?.allowStudentPetitions || isProfessor) && (
-                <Link to={`/ash-typescript/create?classroomId=${id}`}>
+                <Link to={ROUTES.createPetitionWithClassroom(id!)}>
                   <Button>
                     <Plus className="w-4 h-4 mr-2" />
                     New Petition
@@ -352,7 +356,7 @@ export default function ClassroomDetailPage() {
               <Card className="p-8 text-center">
                 <p className="text-muted-foreground mb-4">No petitions in this classroom yet</p>
                 {(classroom?.allowStudentPetitions || isProfessor) && (
-                  <Link to={`/ash-typescript/create?classroomId=${id}`}>
+                  <Link to={ROUTES.createPetitionWithClassroom(id!)}>
                     <Button>
                       <Plus className="w-4 h-4 mr-2" />
                       Create the First Petition

--- a/assets/js/pages/classrooms-page.tsx
+++ b/assets/js/pages/classrooms-page.tsx
@@ -6,6 +6,8 @@ import { getMyClassrooms, buildCSRFHeaders } from "@/js/ash_rpc"
 import { ClassroomList } from "../features/classroom/classroom-list"
 import { JoinClassroomForm } from "../features/classroom/join-classroom-form"
 import { useAuth } from "../contexts/auth-context"
+import { ROUTES } from "@/lib/routes"
+import { useDocumentTitle } from "../hooks/use-document-title"
 
 // Skeleton loading state
 function ClassroomsLoadingState() {
@@ -52,6 +54,8 @@ function ClassroomsLoadingState() {
 }
 
 export default function ClassroomsPage() {
+  useDocumentTitle("Classrooms")
+
   const { user: currentUser } = useAuth()
   const currentUserId = currentUser?.id
 
@@ -119,7 +123,7 @@ export default function ClassroomsPage() {
               View and manage your classrooms or join a new one
             </p>
           </div>
-          <Link to="/ash-typescript/classrooms/new">
+          <Link to={ROUTES.classroomNew}>
             <Button className="bg-primary text-primary-foreground hover:bg-primary/90">
               <Plus className="w-4 h-4 mr-2" />
               Create Classroom

--- a/assets/js/pages/create-classroom-page.tsx
+++ b/assets/js/pages/create-classroom-page.tsx
@@ -8,8 +8,12 @@ import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { Card } from "@/components/ui/card"
 import { createClassroom, buildCSRFHeaders } from "@/js/ash_rpc"
+import { ROUTES } from "@/lib/routes"
+import { useDocumentTitle } from "../hooks/use-document-title"
 
 export default function CreateClassroomPage() {
+  useDocumentTitle("New Classroom")
+
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
@@ -40,7 +44,7 @@ export default function CreateClassroomPage() {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["myClassrooms"] })
-      navigate(`/ash-typescript/classrooms/${data.id}`)
+      navigate(ROUTES.classroom(data.id))
     },
     onError: (err: Error) => {
       setErrors({ general: err.message })
@@ -69,7 +73,7 @@ export default function CreateClassroomPage() {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12 max-w-2xl">
         {/* Back Link */}
         <Link
-          to="/ash-typescript/classrooms"
+          to={ROUTES.classrooms}
           className="inline-flex items-center text-muted-foreground hover:text-foreground mb-6 transition-colors"
         >
           <ArrowLeft className="w-4 h-4 mr-2" />
@@ -146,7 +150,7 @@ export default function CreateClassroomPage() {
             </div>
 
             <div className="flex justify-end gap-3 pt-4">
-              <Link to="/ash-typescript/classrooms">
+              <Link to={ROUTES.classrooms}>
                 <Button type="button" variant="outline" disabled={createMutation.isPending}>
                   Cancel
                 </Button>

--- a/assets/js/pages/create-petition-page.tsx
+++ b/assets/js/pages/create-petition-page.tsx
@@ -15,6 +15,7 @@ import { AlertCircle, CheckCircle2, Lightbulb } from "lucide-react"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { buildCSRFHeaders, createPetition, getCategories } from "../ash_rpc"
 import { useQuery } from "@tanstack/react-query"
+import { useDocumentTitle } from "../hooks/use-document-title"
 
 function CreatePetitionLoadingState() {
   return (
@@ -116,6 +117,8 @@ function CreatePetitionLoadingState() {
 }
 
 export default function CreatePetitionPage() {
+  useDocumentTitle("Start a Petition")
+
   const [formData, setFormData] = useState({
     title: "",
     description: "",

--- a/assets/js/pages/dashboard-page.tsx
+++ b/assets/js/pages/dashboard-page.tsx
@@ -12,6 +12,8 @@ import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { CleanResource } from "@/lib/types"
 import { useAuth } from "../contexts/auth-context"
+import { ROUTES } from "@/lib/routes"
+import { useDocumentTitle } from "../hooks/use-document-title"
 
 type User = CleanResource<UserResourceSchema>
 
@@ -160,6 +162,8 @@ function DashboardLoadingState() {
 }
 
 export default function Dashboard() {
+  useDocumentTitle("Dashboard")
+
   const { user: currentUser, isLoading: authLoading, isAuthenticated } = useAuth()
 
   const userQuery = useQuery({
@@ -286,7 +290,7 @@ export default function Dashboard() {
                 3
               </span>
             </Button>
-            <Link to={`/ash-typescript/create`}>
+            <Link to={ROUTES.createPetition}>
               <Button className="bg-primary text-primary-foreground hover:bg-primary/90">
                 <TrendingUp className="w-4 h-4 mr-2" />
                 Start New Petition

--- a/assets/js/pages/home-page.tsx
+++ b/assets/js/pages/home-page.tsx
@@ -5,8 +5,11 @@ import { Stats } from "../features/home/stats"
 import { PetitionGrid } from "../features/petition/petition-grid"
 import { CreatePetitionCTA } from "../features/home/create-petition-cta"
 import { useQuery } from "@tanstack/react-query"
+import { useDocumentTitle } from "../hooks/use-document-title"
 
 export const HomePage = () => {
+  useDocumentTitle("Home")
+
   const petitionsQuery = useQuery({
     queryKey: ["homePetitions"],
     queryFn: async () => {

--- a/assets/js/pages/not-found-page.tsx
+++ b/assets/js/pages/not-found-page.tsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom"
+import { ROUTES } from "@/lib/routes"
+import { useDocumentTitle } from "../hooks/use-document-title"
+
+export function NotFoundPage() {
+  useDocumentTitle("Not Found")
+
+  return (
+    <main className="min-h-screen bg-background flex items-center justify-center">
+      <div className="text-center max-w-md px-4">
+        <p className="text-6xl font-bold text-primary mb-4">404</p>
+        <h1 className="text-2xl font-semibold text-foreground mb-2">Page not found</h1>
+        <p className="text-muted-foreground mb-8">
+          The page you're looking for doesn't exist or has moved.
+        </p>
+        <Link
+          to={ROUTES.home}
+          className="inline-flex items-center justify-center bg-primary text-primary-foreground hover:bg-primary/90 px-6 py-3 rounded-md font-medium transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/assets/js/pages/petition-index-page.tsx
+++ b/assets/js/pages/petition-index-page.tsx
@@ -11,6 +11,7 @@ import { CleanResource } from "@/lib/types"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useDocumentTitle } from "../hooks/use-document-title"
 
 type Petition = CleanResource<PetitionResourceSchema>
 // type Petition = InferGetPetitionsResult<>
@@ -278,6 +279,7 @@ export default function PetitionIndexPage() {
   const [commentText, setCommentText] = useState("")
   const [commentError, setCommentError] = useState<string | null>(null)
   const queryClient = useQueryClient()
+  useDocumentTitle(petition?.title ?? "Petition")
 
   const createCommentMutation = useMutation({
     mutationFn: async (petitionId: string) => {

--- a/assets/lib/routes.ts
+++ b/assets/lib/routes.ts
@@ -1,0 +1,2 @@
+// Re-exports so the `@/lib/routes` alias resolves alongside relative imports.
+export { DEFAULT_PATH, ROUTES } from "../js/lib/routes"

--- a/lib/petitionu_web/auth_overrides.ex
+++ b/lib/petitionu_web/auth_overrides.ex
@@ -1,20 +1,19 @@
 defmodule PetitionuWeb.AuthOverrides do
   use AshAuthentication.Phoenix.Overrides
 
-  # configure your UI overrides here
+  alias AshAuthentication.Phoenix.Components
 
-  # First argument to `override` is the component name you are overriding.
-  # The body contains any number of configurations you wish to override
-  # Below are some examples
+  # Drop the Ash logo banner; show the PetitionU wordmark instead.
+  override Components.Banner do
+    set :image_url, nil
+    set :dark_image_url, nil
+    set :text, "PetitionU"
+    set :text_class, "text-2xl font-semibold text-base-content"
+    set :root_class, "w-full flex justify-center py-8"
+  end
 
-  # For a complete reference, see https://hexdocs.pm/ash_authentication_phoenix/ui-overrides.html
-
-  # override AshAuthentication.Phoenix.Components.Banner do
-  #   set :image_url, "https://media.giphy.com/media/g7GKcSzwQfugw/giphy.gif"
-  #   set :text_class, "bg-red-500"
-  # end
-
-  # override AshAuthentication.Phoenix.Components.SignIn do
-  #  set :show_banner, false
-  # end
+  # The sign-in page carries its own branding; hide the banner there.
+  override Components.SignIn do
+    set :show_banner, false
+  end
 end

--- a/lib/petitionu_web/components/layouts/root.html.heex
+++ b/lib/petitionu_web/components/layouts/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title default="Petitionu" suffix=" · Phoenix Framework">
+    <.live_title default="PetitionU" suffix=" · PetitionU">
       {assigns[:page_title]}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />

--- a/lib/petitionu_web/controllers/page_controller.ex
+++ b/lib/petitionu_web/controllers/page_controller.ex
@@ -2,7 +2,7 @@ defmodule PetitionuWeb.PageController do
   use PetitionuWeb, :controller
 
   def home(conn, _params) do
-    render(conn, :home)
+    redirect(conn, to: "/ash-typescript")
   end
 
   def index conn, _params do

--- a/test/petitionu_web/controllers/page_controller_test.exs
+++ b/test/petitionu_web/controllers/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule PetitionuWeb.PageControllerTest do
   use PetitionuWeb.ConnCase
 
-  test "GET /", %{conn: conn} do
+  test "GET / redirects to the SPA", %{conn: conn} do
     conn = get(conn, ~p"/")
-    assert html_response(conn, 200) =~ "Peace of mind from prototype to production"
+    assert redirected_to(conn) == "/ash-typescript"
   end
 end


### PR DESCRIPTION
Fixes #10

**For the user:** `/` now lands on the SPA, unknown routes show a branded 404, and each page sets its own tab title. Footer added for container consistency. Routing now lives in one typed constant map.

**For the maintainer:** `assets/js/lib/routes.ts` is the single source of truth for SPA paths (`@/lib/routes` re-exports it). Hardcoded `/ash-typescript` strings removed from 12 files. `PageController.home` redirects to `/ash-typescript`. `App.tsx` now uses `DEFAULT_PATH` and a wildcard 404 route. `useDocumentTitle` hook syncs titles. Auth pages branded via `AuthOverrides`. CSS: Newsreader font removed, Geist kept, theming split documented.

**Verification:** `mix compile` clean, `mix test` 24 passed, `tsc --noEmit` clean, grep confirms only `DEFAULT_PATH` holds the path.

Stack: base for #11 and #12.